### PR TITLE
Fixed #69544: Show the author of a query in its page.

### DIFF
--- a/quarry/web/templates/query/view.html
+++ b/quarry/web/templates/query/view.html
@@ -34,6 +34,7 @@
     <div class="query-status">
         <span class="only-not-published">This query is marked as a draft</span>
         <span class="only-published">This query has been published</span>
+        by <a href="/{{query.user.username}}">{{query.user.username}}</a>.
         {% if jsvars.can_edit %}
             <button id="toggle-publish" type="button" class="btn btn-default btn-xs">
                 <span class="only-not-published">Publish</span>


### PR DESCRIPTION
This patch shows author info of a query in query details page.
